### PR TITLE
Build with zig-0.8.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Zig setup
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.7.1
+          version: 0.8.0
 
       - run: mkdir ${{ env.TARGET }}
 
@@ -83,7 +83,7 @@ jobs:
       - name: Zig setup
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.7.1
+          version: 0.8.0
 
       - run: sudo apt install zip
       - run: mkdir ${{ env.TARGET }}
@@ -122,7 +122,7 @@ jobs:
       - name: Zig setup
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.7.1
+          version: 0.8.0
 
       - run: mkdir ${{ env.TARGET }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Zig setup
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.7.1
+          version: 0.8.0
 
       - name: Run all tests
         run: zig build test
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.7.1
+          version: 0.8.0
 
       - name: Check formatting
         run: zig fmt --check .

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 zig-cache/
+zig-out/
 *.code-workspace
 .idea/
 deps.zig

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gyro badge](https://img.shields.io/badge/gyro-nestedtext-blue)](https://astrolabe.pm/#/tag/nestedtext)
 
 
-A NestedText parser written in Zig 0.7 targeting [NestedText v1.3](https://nestedtext.org/en/v1.3/).
+A NestedText parser written in Zig 0.8 targeting [NestedText v1.3](https://nestedtext.org/en/v1.3/).
 
 See my [Zig NestedText Library blog post](https://www.lewisgaul.co.uk/blog/coding/2021/04/18/zig-nestedtext/).
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -63,7 +63,7 @@ fn parseArgs() !Args {
 
     // Initalize diagnostics for reporting parsing errors.
     var diag = clap.Diagnostic{};
-    var clap_args = clap.parse(clap.Help, &params, .{ .diagnostic =  &diag }) catch |err| {
+    var clap_args = clap.parse(clap.Help, &params, .{ .diagnostic = &diag }) catch |err| {
         diag.report(stderr, err) catch {};
         return err;
     };

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -62,8 +62,8 @@ fn parseArgs() !Args {
     };
 
     // Initalize diagnostics for reporting parsing errors.
-    var diag: clap.Diagnostic = undefined;
-    var clap_args = clap.parse(clap.Help, &params, allocator, &diag) catch |err| {
+    var diag = clap.Diagnostic{};
+    var clap_args = clap.parse(clap.Help, &params, .{ .diagnostic =  &diag }) catch |err| {
         diag.report(stderr, err) catch {};
         return err;
     };

--- a/src/nestedtext.zig
+++ b/src/nestedtext.zig
@@ -569,7 +569,7 @@ test "parse empty" {
     var tree = try p.parse("");
     defer tree.deinit();
 
-    testing.expectEqual(Value{ .String = "" }, tree.root);
+    try testing.expectEqual(Value{ .String = "" }, tree.root);
 }
 
 test "basic parse: string" {
@@ -584,7 +584,7 @@ test "basic parse: string" {
     var tree = try p.parse(s);
     defer tree.deinit();
 
-    testing.expectEqualStrings("this is a\nmultiline\nstring", tree.root.String);
+    try testing.expectEqualStrings("this is a\nmultiline\nstring", tree.root.String);
 }
 
 test "basic parse: list" {
@@ -600,8 +600,8 @@ test "basic parse: list" {
 
     const array: Array = tree.root.List;
 
-    testing.expectEqualStrings("foo", array.items[0].String);
-    testing.expectEqualStrings("bar", array.items[1].String);
+    try testing.expectEqualStrings("foo", array.items[0].String);
+    try testing.expectEqualStrings("bar", array.items[1].String);
 }
 
 test "basic parse: object" {
@@ -617,8 +617,8 @@ test "basic parse: object" {
 
     const map: Map = tree.root.Object;
 
-    testing.expectEqualStrings("1", map.get("foo").?.String);
-    testing.expectEqualStrings("False", map.get("bar").?.String);
+    try testing.expectEqualStrings("1", map.get("foo").?.String);
+    try testing.expectEqualStrings("False", map.get("bar").?.String);
 }
 
 test "nested parse: object inside object" {
@@ -637,10 +637,10 @@ test "nested parse: object inside object" {
 
     const map: Map = tree.root.Object;
 
-    testing.expectEqualStrings("1", map.get("foo").?.String);
-    testing.expectEqualStrings("", map.get("baz").?.String);
-    testing.expectEqualStrings("2", map.get("bar").?.Object.get("nest1").?.String);
-    testing.expectEqualStrings("3", map.get("bar").?.Object.get("nest2").?.String);
+    try testing.expectEqualStrings("1", map.get("foo").?.String);
+    try testing.expectEqualStrings("", map.get("baz").?.String);
+    try testing.expectEqualStrings("2", map.get("bar").?.Object.get("nest1").?.String);
+    try testing.expectEqualStrings("3", map.get("bar").?.Object.get("nest2").?.String);
 }
 
 test "failed parse: multi-line string indent" {
@@ -653,9 +653,9 @@ test "failed parse: multi-line string indent" {
         \\   > bar
     ;
 
-    testing.expectError(error.InvalidIndentation, p.parse(s));
-    testing.expectEqual(@as(usize, 2), diags.ParseError.lineno);
-    testing.expectEqualStrings(
+    try testing.expectError(error.InvalidIndentation, p.parse(s));
+    try testing.expectEqual(@as(usize, 2), diags.ParseError.lineno);
+    try testing.expectEqualStrings(
         "Invalid indentation of multi-line string",
         diags.ParseError.message,
     );
@@ -669,8 +669,8 @@ test "stringify: empty" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try tree.root.stringify(.{}, fbs.outStream());
-    testing.expectEqualStrings("", fbs.getWritten());
+    try tree.root.stringify(.{}, fbs.writer());
+    try testing.expectEqualStrings("", fbs.getWritten());
 }
 
 test "stringify: string" {
@@ -687,8 +687,8 @@ test "stringify: string" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try tree.root.stringify(.{}, fbs.outStream());
-    testing.expectEqualStrings(s, fbs.getWritten());
+    try tree.root.stringify(.{}, fbs.writer());
+    try testing.expectEqualStrings(s, fbs.getWritten());
 }
 
 test "stringify: list" {
@@ -704,8 +704,8 @@ test "stringify: list" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try tree.root.stringify(.{}, fbs.outStream());
-    testing.expectEqualStrings(s, fbs.getWritten());
+    try tree.root.stringify(.{}, fbs.writer());
+    try testing.expectEqualStrings(s, fbs.getWritten());
 }
 
 test "stringify: object" {
@@ -721,8 +721,8 @@ test "stringify: object" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try tree.root.stringify(.{}, fbs.outStream());
-    testing.expectEqualStrings(s, fbs.getWritten());
+    try tree.root.stringify(.{}, fbs.writer());
+    try testing.expectEqualStrings(s, fbs.getWritten());
 }
 
 test "stringify: multiline string inside object" {
@@ -740,8 +740,8 @@ test "stringify: multiline string inside object" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try tree.root.stringify(.{}, fbs.outStream());
-    testing.expectEqualStrings(s, fbs.getWritten());
+    try tree.root.stringify(.{}, fbs.writer());
+    try testing.expectEqualStrings(s, fbs.getWritten());
 }
 
 test "convert to JSON: empty" {
@@ -755,8 +755,8 @@ test "convert to JSON: empty" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try json_tree.root.jsonStringify(.{}, fbs.outStream());
-    testing.expectEqualStrings("\"\"", fbs.getWritten());
+    try json_tree.root.jsonStringify(.{}, fbs.writer());
+    try testing.expectEqualStrings("\"\"", fbs.getWritten());
 }
 
 test "convert to JSON: string" {
@@ -776,8 +776,8 @@ test "convert to JSON: string" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try json_tree.root.jsonStringify(.{}, fbs.outStream());
-    testing.expectEqualStrings("\"this is a\\nmultiline\\nstring\"", fbs.getWritten());
+    try json_tree.root.jsonStringify(.{}, fbs.writer());
+    try testing.expectEqualStrings("\"this is a\\nmultiline\\nstring\"", fbs.getWritten());
 }
 
 test "convert to JSON: list" {
@@ -796,11 +796,11 @@ test "convert to JSON: list" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try json_tree.root.jsonStringify(.{}, fbs.outStream());
+    try json_tree.root.jsonStringify(.{}, fbs.writer());
     const expected_json =
         \\["foo","bar"]
     ;
-    testing.expectEqualStrings(expected_json, fbs.getWritten());
+    try testing.expectEqualStrings(expected_json, fbs.getWritten());
 }
 
 test "convert to JSON: object" {
@@ -819,12 +819,12 @@ test "convert to JSON: object" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try json_tree.root.jsonStringify(.{}, fbs.outStream());
+    try json_tree.root.jsonStringify(.{}, fbs.writer());
     // TODO: Order of objects not yet guaranteed.
     const expected_json =
         \\{"foo":"1","bar":"False"}
     ;
-    testing.expectEqualStrings(expected_json, fbs.getWritten());
+    try testing.expectEqualStrings(expected_json, fbs.getWritten());
 }
 
 test "convert to JSON: object inside object" {
@@ -844,11 +844,11 @@ test "convert to JSON: object inside object" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try json_tree.root.jsonStringify(.{}, fbs.outStream());
+    try json_tree.root.jsonStringify(.{}, fbs.writer());
     const expected_json =
         \\{"bar":{"nest1":"1","nest2":"2"}}
     ;
-    testing.expectEqualStrings(expected_json, fbs.getWritten());
+    try testing.expectEqualStrings(expected_json, fbs.getWritten());
 }
 
 test "convert to JSON: list inside object" {
@@ -868,11 +868,11 @@ test "convert to JSON: list inside object" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try json_tree.root.jsonStringify(.{}, fbs.outStream());
+    try json_tree.root.jsonStringify(.{}, fbs.writer());
     const expected_json =
         \\{"bar":["nest1","nest2"]}
     ;
-    testing.expectEqualStrings(expected_json, fbs.getWritten());
+    try testing.expectEqualStrings(expected_json, fbs.getWritten());
 }
 
 test "convert to JSON: multiline string inside object" {
@@ -892,11 +892,11 @@ test "convert to JSON: multiline string inside object" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try json_tree.root.jsonStringify(.{}, fbs.outStream());
+    try json_tree.root.jsonStringify(.{}, fbs.writer());
     const expected_json =
         \\{"foo":"multi\nline"}
     ;
-    testing.expectEqualStrings(expected_json, fbs.getWritten());
+    try testing.expectEqualStrings(expected_json, fbs.getWritten());
 }
 
 test "convert to JSON: multiline string inside list" {
@@ -917,9 +917,9 @@ test "convert to JSON: multiline string inside list" {
 
     var buffer: [128]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buffer);
-    try json_tree.root.jsonStringify(.{}, fbs.outStream());
+    try json_tree.root.jsonStringify(.{}, fbs.writer());
     const expected_json =
         \\["multi\nline",""]
     ;
-    testing.expectEqualStrings(expected_json, fbs.getWritten());
+    try testing.expectEqualStrings(expected_json, fbs.getWritten());
 }

--- a/src/nestedtext.zig
+++ b/src/nestedtext.zig
@@ -190,7 +190,11 @@ fn fromJsonInternal(allocator: *Allocator, json_value: json.Value) anyerror!Valu
     switch (json_value) {
         .Null => return Value{ .String = "null" },
         .Bool => |inner| return Value{ .String = if (inner) "true" else "false" },
-        .Integer, .Float, .String, .NumberString, => {
+        .Integer,
+        .Float,
+        .String,
+        .NumberString,
+        => {
             var buffer = ArrayList(u8).init(allocator);
             errdefer buffer.deinit();
             switch (json_value) {
@@ -328,32 +332,29 @@ pub const Parser = struct {
             } else if (parseString(tab_stripped)) |index| {
                 kind = if (tab_stripped.len < stripped.len)
                     .InvalidTabIndent
-                else
-                    .{
-                        .String = .{
-                            .value = full_line[text.len - stripped.len + index ..],
-                        },
-                    };
+                else .{
+                    .String = .{
+                        .value = full_line[text.len - stripped.len + index ..],
+                    },
+                };
             } else if (parseList(tab_stripped)) |value| {
                 kind = if (tab_stripped.len < stripped.len)
                     .InvalidTabIndent
-                else
-                    .{
-                        .List = .{
-                            .value = if (value.len > 0) value else null,
-                        },
-                    };
+                else .{
+                    .List = .{
+                        .value = if (value.len > 0) value else null,
+                    },
+                };
             } else if (parseObject(tab_stripped)) |result| {
                 kind = if (tab_stripped.len < stripped.len)
                     .InvalidTabIndent
-                else
-                    .{
-                        .Object = .{
-                            .key = result[0].?,
-                            // May be null if the value is on the following line(s).
-                            .value = result[1],
-                        },
-                    };
+                else .{
+                    .Object = .{
+                        .key = result[0].?,
+                        // May be null if the value is on the following line(s).
+                        .value = result[1],
+                    },
+                };
             } else {
                 kind = .Unrecognised;
             }
@@ -407,8 +408,7 @@ pub const Parser = struct {
 
         tree.root = if (lines.peekNext() != null)
             try p.readValue(&tree.arena.allocator, &lines) // Recursively parse
-        else
-            .{ .String = "" };
+        else .{ .String = "" };
 
         return tree;
     }

--- a/src/nestedtext.zig
+++ b/src/nestedtext.zig
@@ -204,11 +204,8 @@ fn fromJsonInternal(allocator: *Allocator, json_value: json.Value) anyerror!Valu
                 .Float => |inner| {
                     try buffer.writer().print("{e}", .{inner});
                 },
-                .String => |inner| {
+                .String, .NumberString => |inner| {
                     try buffer.writer().print("{s}", .{inner});
-                },
-                .NumberString => |inner| {
-                    try buffer.writer().print("{e}", .{std.fmt.fmtSliceEscapeLower(inner)});
                 },
                 else => unreachable,
             }

--- a/tests/testsuite.zig
+++ b/tests/testsuite.zig
@@ -88,15 +88,15 @@ fn printWithVisibleNewlines(source: []const u8) void {
     while (std.mem.indexOf(u8, source[i..], "\n")) |nl| : (i += nl + 1) {
         printLine(source[i .. i + nl]);
     }
-    print("{}<ETX>\n", .{source[i..]}); // End of Text (ETX)
+    print("{s}<ETX>\n", .{source[i..]}); // End of Text (ETX)
 }
 
 fn printLine(line: []const u8) void {
     if (line.len != 0) switch (line[line.len - 1]) {
-        ' ', '\t' => print("{}<CR>\n", .{line}), // Carriage return
+        ' ', '\t' => print("{s}<CR>\n", .{line}), // Carriage return
         else => {},
     };
-    print("{}\n", .{line});
+    print("{s}\n", .{line});
 }
 
 // Helpers
@@ -271,7 +271,7 @@ fn testAll(base_dir: std.fs.Dir) !void {
         for (failures.items) |name|
             print(" {s}\n", .{name});
         print("\n", .{});
-        testing.expect(false);
+        return error.TestFailure;
     }
 }
 


### PR DESCRIPTION
Using zig-master branch of zig-clap
Builds with zig-0.8.x

This just updates nt to build with zig-0.8.x and zig-clap current.

Zig-clap clap.parse got rid of the allocator requirement.

Zig's HashMap Entry no longer gives direct access to key and value, instead giving key_ptr and value_ptr. I just adjusted so that we're dereferencing the pointers with ptr.* syntax.

Check my implementation of Json .NumberString, nestedtext.zig lines 193, 206-208. That's the only part I'm unsure of. This just puts it in scientific notation making the assumption that it's a float. I'm not well versed in Json so I don't know if that case might also represent and integer.

That's about it.