### PR TITLE
Implement 'fromArbitraryType()' - reverse of parseTyped()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## v0.3.1 (2021-07-10)
+
+- Add support for converting arbitrary Zig types to NestedText via `fromArbitraryType()` (inverse of `Parser.parseTyped()`)
+- Fix bug in `parseTypedFree()` when passing in a `Void` type
+- Fix bug parsing into enum types with `parseTyped()`
+
+
 ## v0.3.0 (2021-06-24)
 
 - Add initial support for parsing into a comptime type [#15](https://github.com/LewisGaul/zig-nestedtext/pull/15)

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,6 +1,6 @@
 pkgs:
   nestedtext:
-    version: 0.3.0
+    version: 0.3.1
     description: "Zig NestedText parser library - a simple human readable data format based on YAML"
     license: MIT
     source_url: "https://github.com/LewisGaul/zig-nestedtext"


### PR DESCRIPTION
Also includes bump to v0.3.1, with a fix to handling of enums in `parseTyped()`.

Fixes #19.