### PR TITLE
Fixed incorrect data being sent to allocator.dupe() in fromArbitraryTypeInternal() in case of slice type

### DIFF
--- a/src/nestedtext.zig
+++ b/src/nestedtext.zig
@@ -1844,3 +1844,26 @@ test "from type: array/slice" {
         try testToJson(expected_json, tree);
     }
 }
+
+test "from type: union with []const u8" {
+    const MyUnion = union(enum) {
+        foo: []const u8,
+        bar,
+    };
+    {
+        const tree = try fromArbitraryType(
+            testing.allocator,
+            MyUnion{ .foo = "baz" },
+        );
+        defer tree.deinit();
+        try testStringify("> baz", tree);
+    }
+    {
+        const tree = try fromArbitraryType(
+            testing.allocator,
+            MyUnion.bar,
+        );
+        defer tree.deinit();
+        try testStringify("> bar", tree);
+    }
+}

--- a/src/nestedtext.zig
+++ b/src/nestedtext.zig
@@ -390,7 +390,7 @@ fn fromArbitraryTypeInternal(allocator: *Allocator, value: anytype) anyerror!Val
                     // Always treating this as a string - may want the option to
                     // treat as an array and handle escapes (see
                     // std.json.StringifyOptions).
-                    return Value{ .String = allocator.dupe(ptr_info.child) };
+                    return Value{ .String = try allocator.dupe(u8, value) };
                 } else {
                     var array = Array.init(allocator);
                     errdefer array.deinit();


### PR DESCRIPTION
Affected Union types with void tags as well as Optional strings

This was causing a compilation failure with tagged unions which had a void tag type, as well as with optional strings. The error appeared as:
```
/home/jeang3nie/src/zig-nestedtext/src/nestedtext.zig:393:59: error: expected type '[]const u8', found '@typeInfo(@typeInfo(@TypeOf(std.mem.Allocator.dupe)).Fn.return_type.?).ErrorUnion.error_set![]u8'
                    return Value{ .String = allocator.dupe(u8, value) };
                                                          ^
/home/jeang3nie/src/zig-nestedtext/src/nestedtext.zig:344:49: note: called from here
                return fromArbitraryTypeInternal(allocator, payload);
                                                ^
/home/jeang3nie/src/zig-nestedtext/src/nestedtext.zig:370:50: note: called from here
                    try fromArbitraryTypeInternal(allocator, @field(value, Field.name)),
                                                 ^
/home/jeang3nie/src/zig-nestedtext/src/nestedtext.zig:330:46: note: called from here
    tree.root = try fromArbitraryTypeInternal(&tree.arena.allocator, value);
                                             ^
./src/main.zig:113:42: note: called from here
    const chld = try nt.fromArbitraryType(allocator, Child.default());
                                         ^
./src/main.zig:77:29: note: called from here
pub fn main() anyerror!void {
```
Apparently only the Type was being sent to allocator.dupe, as well as not handling OOM errors should allocation fail. This fix glosses over the latter by using `try`, but it appears that happens also elsewhere in the code so I'm OK with it if you are.

